### PR TITLE
Prepare v4.1.2 for IntelliJ IDEA 2026.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - Restore builds against IntelliJ IDEA 2026.2 by upgrading the IntelliJ Platform Gradle Plugin from `2.11.0` to `2.18.1`
+- Serialize production and test bytecode instrumentation to prevent clean parallel CI builds from racing
 
 ## [4.1.0] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
 # Resin Pura Changelog
 
 ## [Unreleased]
+
+## [4.1.2] - 2026-07-20
+
 ### Changed
-- Bump `pluginVersion` to `4.0.5`
-- Update IntelliJ Platform target to `2026.1`
-- Expand compatible build range to `261.*`
+- Update the IntelliJ Platform target to `2026.2`
+- Expand the compatible build range to `262.*`
+- Upgrade the Kotlin Gradle Plugin from `2.3.10` to `2.3.20` for supported Gradle 9.2 builds
+
+### Fixed
+- Restore builds against IntelliJ IDEA 2026.2 by upgrading the IntelliJ Platform Gradle Plugin from `2.11.0` to `2.18.1`
+
+## [4.1.0] - 2026-04-08
+
+### Changed
+- Modernize the Resin run configuration and deployment editors with the Kotlin UI DSL
+- Improve remote host and target validation
+- Replace obsolete utility code with modern Kotlin APIs and stronger null-safety checks
+- Refresh the plugin icon
 
 ## [3.0.0] - 2025-12-10
 
@@ -15,5 +29,7 @@
 - JMX-based monitoring and control
 - Support for multiple Resin versions (2.x, 3.x, 4.x)
 
-[Unreleased]: https://github.com/dingdangmaoup/resin-pura/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/dingdangmaoup/resin-pura/compare/v4.1.2...HEAD
+[4.1.2]: https://github.com/dingdangmaoup/resin-pura/compare/v4.1.0...v4.1.2
+[4.1.0]: https://github.com/dingdangmaoup/resin-pura/releases/tag/v4.1.0
 [3.0.0]: https://github.com/dingdangmaoup/resin-pura/releases/tag/v3.0.0

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ The plugin ZIP will be created in `build/distributions/`.
 
 ## Compatibility
 
-- IntelliJ IDEA 2024.2+ (Build 242+)
-- Supports IntelliJ IDEA Ultimate Edition
+- IntelliJ IDEA 2024.2–2026.2 (Build 242–262.*)
+- IntelliJ IDEA Ultimate Edition
 
 ## Upstream Source
 JetBrains obsolete plugin repository (original Resin plugin):

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,6 +128,12 @@ tasks {
         gradleVersion = providers.gradleProperty("gradleVersion").get()
     }
 
+    // IntelliJ's production and test instrumenters share mutable state and can
+    // fail nondeterministically when a clean build runs both tasks in parallel.
+    named("instrumentTestCode") {
+        mustRunAfter("instrumentCode")
+    }
+
     publishPlugin {
         dependsOn(patchChangelog)
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.dingdangmaoup
 pluginName = Resin Pura
 pluginRepositoryUrl = https://github.com/dingdangmaoup/resin-pura
 # SemVer format -> https://semver.org
-pluginVersion = 4.1.1
+pluginVersion = 4.1.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@ junit = "4.13.2"
 opentest4j = "1.3.0"
 
 # plugins
-intelliJPlatform = "2.11.0"
-kotlin = "2.3.10"
+intelliJPlatform = "2.18.1"
+kotlin = "2.3.20"
 kover = "0.9.7"
 changelog = "2.5.0"
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,7 +9,7 @@
 
     <description>
         基于 JetBrains 已停止维护的 Resin 开源插件（intellij-obsolete-plugins/resin）进行升级迁移，
-        持续适配新版 IntelliJ IDEA（2025.3+）。
+        持续适配 IntelliJ IDEA 2024.2–2026.2（Build 242–262.*）。
     </description>
     <vendor>dingdangmaoup</vendor>
     <category>Deployment</category>


### PR DESCRIPTION
## What changed

- upgrade the IntelliJ Platform Gradle Plugin from 2.11.0 to 2.18.1
- upgrade the Kotlin Gradle Plugin from 2.3.10 to 2.3.20 for Gradle 9.2 support
- serialize production and test bytecode instrumentation when both tasks are present
- prepare plugin version 4.1.2 for IntelliJ IDEA 2026.2 / build 262.*
- refresh the changelog, README compatibility range, and plugin metadata

## Why

The 2026.2 platform module descriptors include namespace and visibility attributes that IntelliJ Platform Gradle Plugin 2.11.0 cannot deserialize. This caused the `check` task to fail while resolving `intellijPlatformTestClasspath` before tests could run.

After upgrading the build plugin, clean parallel CI builds exposed a second issue: `instrumentCode` and `instrumentTestCode` could enter IntelliJ's instrumenter concurrently and fail nondeterministically. The tasks are now explicitly ordered while unrelated Gradle work remains parallel.

## Validation

- `./gradlew clean check --no-build-cache --no-configuration-cache --rerun-tasks --stacktrace --console=plain`
- `./gradlew buildPlugin --no-build-cache --no-configuration-cache --rerun-tasks --console=plain`
- `./gradlew getChangelog --no-header --project-version=4.1.2 --console=plain -q`
- `unzip -t 'build/distributions/Resin Pura-4.1.2.zip'`
- `git diff --cached --check`

The local multi-IDE `verifyPlugin` download was interrupted after the JetBrains artifact download remained silent for more than 15 minutes; the PR's dedicated GitHub Actions verifier is the merge gate.
